### PR TITLE
Don't delete dest files if they are found in destPathsToIgnore

### DIFF
--- a/src/main/settings/settings.ts
+++ b/src/main/settings/settings.ts
@@ -24,6 +24,13 @@ async function init(userDataPath: string): Promise<void> {
 	await setSetting('rootDir', userDataPath);
 	await setDefaultSetting('downloadRoms', false);
 	await setDefaultSetting('exportOptimization', 'space');
+	await setDefaultSetting('destPathsToIgnore', [
+		// this file is needed for people in Jotego's beta program.
+		// AMMister doesn't really know anything about it, but if we find it
+		// on a mister (or directory), we should leave it alone
+		// https://github.com/city41/AMMiSTer/issues/124
+		'games/mame/jtbeta.zip',
+	]);
 
 	const hasUpdateDbs = await hasSetting('updateDbs');
 

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -30,6 +30,7 @@ export type Settings = {
 	mostRecentPlanDir?: string;
 	updateDbs: UpdateDbConfig[];
 	exportOptimization: ExportOptimization;
+	destPathsToIgnore: string[];
 };
 
 export type SettingChangeListener = (

--- a/src/renderer/components/settings/SettingsModal/SettingsModal.stories.tsx
+++ b/src/renderer/components/settings/SettingsModal/SettingsModal.stories.tsx
@@ -18,6 +18,7 @@ const mockSettings: Settings = {
 	recentPlans: [],
 	updateDbs: defaultUpdateDbs,
 	exportOptimization: 'space',
+	destPathsToIgnore: [],
 };
 
 export const Basic = () => {


### PR DESCRIPTION
This is primarily to fix deleting jtbeta.zip, but any path can be added to the ignore list.